### PR TITLE
Add DayOfWeek output to the TimeClockNode

### DIFF
--- a/Libs/Nodes/Node.cs
+++ b/Libs/Nodes/Node.cs
@@ -272,6 +272,19 @@ namespace MyNodes.Nodes
                     output.Value = null;
         }
 
+        /// <summary>
+        /// Sets the value of the output with the specified name, if its current value is different.
+        /// </summary>
+        public void SetOutputValue<T>(string outputName, T value)
+        {
+            var valueAsString = value.ToString();
+            var output = GetOutput(outputName);
+            if (output != null && output.Value != valueAsString)
+            {
+                output.Value = valueAsString;
+            }
+        }
+
         public virtual void CheckInputDataTypeIsCorrect(Input input)
         {
             if (input.Value == null)

--- a/Libs/Nodes/Node.cs
+++ b/Libs/Nodes/Node.cs
@@ -273,16 +273,22 @@ namespace MyNodes.Nodes
         }
 
         /// <summary>
-        /// Sets the value of the output with the specified name, if its current value is different.
+        /// Sets the value of the output with the specified name.
         /// </summary>
-        public void SetOutputValue<T>(string outputName, T value)
+        /// <param name="skipIfEqual">Don't set output value if the current value is the same.</param>
+        public void SetOutputValue<T>(string outputName, T value, bool skipIfEqual = false)
         {
             var valueAsString = value.ToString();
             var output = GetOutput(outputName);
-            if (output != null && output.Value != valueAsString)
+            if (output == null)
             {
-                output.Value = valueAsString;
+                return;
             }
+            if (skipIfEqual && output.Value == valueAsString)
+            {
+                return;
+            }
+            output.Value = valueAsString;
         }
 
         public virtual void CheckInputDataTypeIsCorrect(Input input)

--- a/Libs/Nodes/Nodes/TimeClockNode.cs
+++ b/Libs/Nodes/Nodes/TimeClockNode.cs
@@ -10,7 +10,20 @@ namespace MyNodes.Nodes
 {
     public class TimeClockNode : Node
     {
+        private class OutputNames
+        {
+            public const string Millisecond = "Millisecond";
+            public const string Second = "Second";
+            public const string Minute = "Minute";
+            public const string Hour = "Hour";
+            public const string Day = "Day";
+            public const string Month = "Month";
+            public const string Year = "Year";
+            public const string DayOfWeek = "DayOfWeek";
+        }
+
         private const string YearMonthDaySettingKey = "YearMonthDay";
+        private const string DayOfWeekSettingKey = "DayOfWeek";
         private const string UpdateIntervalSettingKey = "UpdateInterval";
 
         private const int DEFAULT_INTERVAL = 50;
@@ -19,13 +32,14 @@ namespace MyNodes.Nodes
 
         public TimeClockNode() : base("Time", "Clock")
         {
-            AddOutput("Millisecond", DataType.Number);
-            AddOutput("Second", DataType.Number);
-            AddOutput("Minute", DataType.Number);
-            AddOutput("Hour", DataType.Number);
+            AddOutput(OutputNames.Millisecond, DataType.Number);
+            AddOutput(OutputNames.Second, DataType.Number);
+            AddOutput(OutputNames.Minute, DataType.Number);
+            AddOutput(OutputNames.Hour, DataType.Number);
 
-            Settings.Add(UpdateIntervalSettingKey, new NodeSetting(NodeSettingType.Number, "Update Interval", DEFAULT_INTERVAL.ToString()));
-            Settings.Add(YearMonthDaySettingKey, new NodeSetting(NodeSettingType.Checkbox, "Day, Month, Year  Outputs", "false"));
+            Settings.Add(UpdateIntervalSettingKey, new NodeSetting(NodeSettingType.Number, "Update interval", DEFAULT_INTERVAL.ToString()));
+            Settings.Add(DayOfWeekSettingKey, new NodeSetting(NodeSettingType.Checkbox, "Day of week output", "false"));
+            Settings.Add(YearMonthDaySettingKey, new NodeSetting(NodeSettingType.Checkbox, "Day, Month, Year outputs", "false"));
 
             options.LogOutputChanges = false;
         }
@@ -38,86 +52,103 @@ namespace MyNodes.Nodes
                 return;
             }
 
-            if ((DateTime.Now - lastUpdateTime).TotalMilliseconds < updateInterval)
+            DateTime now = DateTime.Now;
+
+            if ((now - lastUpdateTime).TotalMilliseconds < updateInterval)
             {
                 return;
             }
 
-            lastUpdateTime = DateTime.Now;
+            lastUpdateTime = now;
 
-            string ms = DateTime.Now.Millisecond.ToString();
-            string s = DateTime.Now.Second.ToString();
-            string mi = DateTime.Now.Minute.ToString();
-            string h = DateTime.Now.Hour.ToString();
-
-            if (Outputs[0].Value != ms) Outputs[0].Value = ms;
-            if (Outputs[1].Value != s) Outputs[1].Value = s;
-            if (Outputs[2].Value != mi) Outputs[2].Value = mi;
-            if (Outputs[3].Value != h) Outputs[3].Value = h;
+            SetOutputValue(OutputNames.Millisecond, now.Millisecond);
+            SetOutputValue(OutputNames.Second, now.Second);
+            SetOutputValue(OutputNames.Minute, now.Minute);
+            SetOutputValue(OutputNames.Hour, now.Hour);
 
             if (Outputs.Count > 4)
             {
-                string d = DateTime.Now.Day.ToString();
-                string mo = DateTime.Now.Month.ToString();
-                string y = DateTime.Now.Year.ToString();
-                string dw = ((int)DateTime.Now.DayOfWeek).ToString();
-
-                if (Outputs[4].Value != d) Outputs[4].Value = d;
-                if (Outputs[5].Value != mo) Outputs[5].Value = mo;
-                if (Outputs[6].Value != y) Outputs[6].Value = y;
-
-                // If the node data is from an older version there wasn't the DayOfWeek column
-                if (Outputs.Count == 8 && Outputs[7].Value != dw) Outputs[7].Value = dw;
+                SetOutputValue(OutputNames.Day, now.Day);
+                SetOutputValue(OutputNames.Month, now.Month);
+                SetOutputValue(OutputNames.Year, now.Year);
+                SetOutputValue(OutputNames.DayOfWeek, (int)now.DayOfWeek);
             }
         }
 
         public override bool SetSettings(Dictionary<string, string> data)
         {
-            if (data[YearMonthDaySettingKey] == "true" && Settings[YearMonthDaySettingKey].Value == "false")
+            if (data[YearMonthDaySettingKey] != Settings[YearMonthDaySettingKey].Value)
             {
-                AddAdditionOutputs();
+                if (data[YearMonthDaySettingKey] == "true")
+                {
+                    AddYearMonthDayOutputs();
+                }
+                else
+                {
+                    RemoveYearMonthDayOutputs();
+                }
             }
-            else if (data[YearMonthDaySettingKey] == "false" && Settings[YearMonthDaySettingKey].Value == "true")
+
+            if (data[DayOfWeekSettingKey] != Settings[DayOfWeekSettingKey].Value)
             {
-                RemoveAdditionOutputs();
+                if (data[DayOfWeekSettingKey] == "true")
+                {
+                    AddDayOfWeekOutput();
+                }
+                else
+                {
+                    RemoveDayOfWeekOutput();
+                }
             }
 
             return base.SetSettings(data);
         }
 
-        public void AddAdditionOutputs()
+        public void AddYearMonthDayOutputs()
         {
-            if (GetOutput("Day") == null)
-                AddOutput("Day", DataType.Number);
+            if (GetOutput(OutputNames.Day) == null)
+                AddOutput(OutputNames.Day, DataType.Number);
 
-            if (GetOutput("Month") == null)
-                AddOutput("Month", DataType.Number);
+            if (GetOutput(OutputNames.Month) == null)
+                AddOutput(OutputNames.Month, DataType.Number);
 
-            if (GetOutput("Year") == null)
-                AddOutput("Year", DataType.Number);
+            if (GetOutput(OutputNames.Year) == null)
+                AddOutput(OutputNames.Year, DataType.Number);
 
-            if (GetOutput("DayOfWeek") == null)
-                AddOutput("DayOfWeek", DataType.Number);
-
-            LogInfo($"Added additional outputs");
+            LogInfo($"Added YearMonthDay outputs");
             UpdateMe();
         }
 
-        public void RemoveAdditionOutputs()
+        public void RemoveYearMonthDayOutputs()
         {
-            if (GetOutput("Day") != null)
-                RemoveOutput("Day");
+            if (GetOutput(OutputNames.Day) != null)
+                RemoveOutput(OutputNames.Day);
 
-            if (GetOutput("Month") != null)
-                RemoveOutput("Month");
+            if (GetOutput(OutputNames.Month) != null)
+                RemoveOutput(OutputNames.Month);
 
-            if (GetOutput("Year") != null)
-                RemoveOutput("Year");
+            if (GetOutput(OutputNames.Year) != null)
+                RemoveOutput(OutputNames.Year);
 
-            if (GetOutput("DayOfWeek") != null)
-                RemoveOutput("DayOfWeek");
+            LogInfo($"Removed YearMonthDay outputs");
+            UpdateMe();
+        }
 
-            LogInfo($"Removed additional outputs");
+        public void AddDayOfWeekOutput()
+        {
+            if (GetOutput(OutputNames.DayOfWeek) == null)
+                AddOutput(OutputNames.DayOfWeek, DataType.Number);
+
+            LogInfo($"Added DayOfWeek output");
+            UpdateMe();
+        }
+
+        public void RemoveDayOfWeekOutput()
+        {
+            if (GetOutput(OutputNames.DayOfWeek) != null)
+                RemoveOutput(OutputNames.DayOfWeek);
+
+            LogInfo($"Removed DayOfWeek output");
             UpdateMe();
         }
 

--- a/Libs/Nodes/Nodes/TimeClockNode.cs
+++ b/Libs/Nodes/Nodes/TimeClockNode.cs
@@ -61,17 +61,17 @@ namespace MyNodes.Nodes
 
             lastUpdateTime = now;
 
-            SetOutputValue(OutputNames.Millisecond, now.Millisecond);
-            SetOutputValue(OutputNames.Second, now.Second);
-            SetOutputValue(OutputNames.Minute, now.Minute);
-            SetOutputValue(OutputNames.Hour, now.Hour);
+            SetOutputValue(OutputNames.Millisecond, now.Millisecond, true);
+            SetOutputValue(OutputNames.Second, now.Second, true);
+            SetOutputValue(OutputNames.Minute, now.Minute, true);
+            SetOutputValue(OutputNames.Hour, now.Hour, true);
 
             if (Outputs.Count > 4)
             {
-                SetOutputValue(OutputNames.Day, now.Day);
-                SetOutputValue(OutputNames.Month, now.Month);
-                SetOutputValue(OutputNames.Year, now.Year);
-                SetOutputValue(OutputNames.DayOfWeek, (int)now.DayOfWeek);
+                SetOutputValue(OutputNames.Day, now.Day, true);
+                SetOutputValue(OutputNames.Month, now.Month, true);
+                SetOutputValue(OutputNames.Year, now.Year, true);
+                SetOutputValue(OutputNames.DayOfWeek, (int)now.DayOfWeek, true);
             }
         }
 


### PR DESCRIPTION
When setting up automatic tasks we often need day of week information. This PR adds a new setting to the `TimeClockNode` to enable the output of `DayOfWeek`, which is a number from 0-6 (mapping Sunday - Saturday), same way as .NET's [DayOfWeek](https://msdn.microsoft.com/en-us/library/system.datetime.dayofweek(v=vs.110).aspx) property.

This PR also adds a helper method in `Node` base class to make it easier to set output values by output name.