### PR TITLE
Fix the mismatch of the input/output of mysensor nodes between what's…

### DIFF
--- a/Libs/Nodes/NodesEngineSerializer.cs
+++ b/Libs/Nodes/NodesEngineSerializer.cs
@@ -6,15 +6,12 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Newtonsoft.Json;
 
 namespace MyNodes.Nodes
 {
     public static class NodesEngineSerializer
     {
-
         private static string SerializeNodesAndLinks(List<Node> nodesList, List<Link> linksList)
         {
             List<Object> list = new List<Object>();
@@ -38,7 +35,6 @@ namespace MyNodes.Nodes
             nodesList = objects.OfType<Node>().ToList();
             linksList = objects.OfType<Link>().ToList();
         }
-
 
         public static string SerializePanel(string panelId, NodesEngine engine)
         {
@@ -73,12 +69,16 @@ namespace MyNodes.Nodes
 
         public static Node DeserializeNode(string json)
         {
-
             JsonSerializerSettings settings = new JsonSerializerSettings();
             settings.TypeNameHandling = TypeNameHandling.All;
             settings.ObjectCreationHandling = ObjectCreationHandling.Replace;
 
-            return JsonConvert.DeserializeObject<Node>(json, settings);
+            var node = JsonConvert.DeserializeObject<Node>(json, settings);
+
+            // For backward compatibility, we'll sort the inputs and outputs from the database
+            node.Inputs.Sort((a, b) => a.SlotIndex.CompareTo(b.SlotIndex));
+            node.Outputs.Sort((a, b) => a.SlotIndex.CompareTo(b.SlotIndex));
+            return node;
         }
     }
 }

--- a/WebController/Controllers/NodeEditorAPIController.cs
+++ b/WebController/Controllers/NodeEditorAPIController.cs
@@ -79,8 +79,7 @@ namespace MyNodes.WebController.Controllers
 
             if (node.Inputs != null)
             {
-                List<Nodes.Input> orderedInputs = node.Inputs.OrderBy(x => x.SlotIndex).ToList();
-                foreach (var input in orderedInputs)
+                foreach (var input in node.Inputs)
                 {
                     litegraphNode.inputs.Add(new LiteGraph.Input
                     {
@@ -94,8 +93,7 @@ namespace MyNodes.WebController.Controllers
 
             if (node.Outputs != null)
             {
-                List<Nodes.Output> orderedOutputs = node.Outputs.OrderBy(x => x.SlotIndex).ToList();
-                foreach (var output in orderedOutputs)
+                foreach (var output in node.Outputs)
                 {
                     List<Nodes.Link> links = engine.GetLinksForOutput(output);
                     if (links != null)


### PR DESCRIPTION
… linked on the editor and what is really linked, when the sensors are not registered in order of sensor id.

Issue: 
---

When a mysensors node has multiple sensors, the order in which those sensors are registered is unpredictable, while `AddInput`/`AddOutput` always adds to the end, so we can have a list of inputs/outputs with different order from their sensor ID - this is not an issue. 

However, when the node editor presents nodes with inputs and outputs, `ConvertNodeToLiteGraphNode(Node)` sorts the inputs and outputs with `SlotIndex`, which is essentially the sensor ID. And later when links are created from the editor, the `slot_index` from editor is directly used as index of inputs/outputs list on the server ([NodeEditorAPIController](https://github.com/gildorwang/MyNodes.NET/blob/9242cf439bf1edb355dad8873e2f26724de42430/WebController/Controllers/NodeEditorAPIController.cs#L282)) which is not sorted. As a result, wrong links are created.

Fix:
---
So essentially the fix is to try making sure the inputs and outputs lists are always sorted by the `SlotIndex`, and also in sync with the one in the editor. The fix is working in my scenarios. Please let me know if I missed anything. 😀 


![image](https://cloud.githubusercontent.com/assets/1061388/25693047/b7f219c2-305b-11e7-88c4-02ef0f690a0e.png)
